### PR TITLE
use values in metadata to decide whether to append domain parameters …

### DIFF
--- a/Combatant/combatant.py
+++ b/Combatant/combatant.py
@@ -87,6 +87,7 @@ def load_combatant(
                 with open(metadata_filepath) as f:
                     metadata = json.load(f)
 
+                # NON-IMAGE-BASED
                 if (
                     "image_based" in metadata
                     and metadata["image_based"] is False
@@ -100,6 +101,7 @@ def load_combatant(
                         **kwargs
                     )
 
+                # IMAGE-BASED - NOT SUPPORTED FOR DSG TOURNAMENT
                 observation = None
                 image_based = True
                 algorithm = metadata["algorithm"]

--- a/Components/plark-game/plark_game/classes/newgame.py
+++ b/Components/plark-game/plark_game/classes/newgame.py
@@ -138,7 +138,8 @@ class Newgame(NewgameBase):
                 metadata['algorithm'],
                 observation,
                 image_based,
-                in_tournament=in_tournament
+                in_tournament=in_tournament,
+                **kwargs
             )
 
 
@@ -159,7 +160,8 @@ class Newgame(NewgameBase):
                 metadata['algorithm'],
                 observation,
                 image_based,
-                in_tournament=in_tournament)
+                in_tournament=in_tournament,
+                **kwargs)
 
 
 def load_agent(file_path, agent_name, basic_agents_filepath, game, in_tournament=False, **kwargs):
@@ -196,23 +198,26 @@ def load_agent(file_path, agent_name, basic_agents_filepath, game, in_tournament
                                 image_based = True
                                 if 'image_based' in metadata and metadata['image_based'] == False: # If the image_based flag is not present asume image based, if it is there and set to false the set to false.
                                         image_based = False
-                                        if not in_tournament:
-                                            if kwargs is None:
-                                                kwargs = {}
 
-                                            kwargs['driving_agent'] = metadata['agentplayer']
-                                            kwargs['normalise'] = metadata['normalise']
-                                            kwargs['domain_params_in_obs'] = metadata['domain_params_in_obs']
+                                        if kwargs is None:
+                                            kwargs = {}
+                                        kwargs['driving_agent'] = metadata['agentplayer']
+                                        kwargs['normalise'] = metadata['normalise']
+                                        kwargs['domain_params_in_obs'] = metadata['domain_params_in_obs']
+                                        if not in_tournament:
                                             observation = Observation(game,**kwargs)
 
                                 print("Filepath of the agent being loaded is: " + agent_filepath)
+
+
                                 if metadata['agentplayer'] == 'pelican':
                                         return Pelican_Agent_Load_Agent(
                                                 agent_filepath,
                                                 metadata['algorithm'],
                                                 observation,
                                                 image_based,
-                                                in_tournament=in_tournament
+                                                in_tournament=in_tournament,
+                                                **kwargs
                                         )
                                 elif metadata['agentplayer'] == 'panther':
                                         return Panther_Agent_Load_Agent(
@@ -220,7 +225,8 @@ def load_agent(file_path, agent_name, basic_agents_filepath, game, in_tournament
                                                 metadata['algorithm'],
                                                 observation,
                                                 image_based,
-                                                in_tournament=in_tournament
+                                                in_tournament=in_tournament,
+                                                **kwargs
                                         )
 
                         else:

--- a/Components/plark-game/plark_game/classes/pelicanAgent_load_agent.py
+++ b/Components/plark-game/plark_game/classes/pelicanAgent_load_agent.py
@@ -20,6 +20,7 @@ class Pelican_Agent_Load_Agent(Pelican_Agent):
         observation=None,
         imaged_based=True,
         in_tournament=False,
+        **kwargs
     ):
 
         if not in_tournament:
@@ -32,6 +33,9 @@ class Pelican_Agent_Load_Agent(Pelican_Agent):
                     self.observation = observation
                 else:
                     raise ValueError("Observation object not passed in to load agent.")
+
+        self.domain_params_in_obs =  ("domain_params_in_obs" in kwargs and kwargs["domain_params_in_obs"])
+        self.normalised =  ("normalise" in kwargs and kwargs["normalise"])
 
         # load the agent
         if os.path.exists(filepath):
@@ -94,5 +98,17 @@ class Pelican_Agent_Load_Agent(Pelican_Agent):
         Modify this if you have an agent that expects a different input, for
         example obs_normalised, or state, or if it needs the domain_parameters.
         """
-        action, _ = self.model.predict(obs, deterministic=False)
+        if self.normalised:
+            ob = obs_normalised
+            domain = domain_parameters_normalised
+        else:
+            ob = obs
+            domain = domain_parameters
+        if self.domain_params_in_obs:
+            if isinstance(ob, list):
+                ob += domain
+            elif isinstance(ob, np.ndarray):
+                ob = np.append(ob, domain)
+
+        action, _ = self.model.predict(ob, deterministic=False)
         return self.action_lookup(action)


### PR DESCRIPTION
Some agents expect an obs array of length 109, as the domain parameters are appended to the original observation.
There is a value in the metadata "domain_params_in_obs" to say whether this is the case, as well as another one called "normalise".
This PR has changes to `load_agent` to pass these metadata params as kwargs to the constructors of `pelicanAgent_loadAgent` and `pantherAgent_loadAgent`, and changes to the `getTournamentAction` method of those, to decide whether or not to append the parameters, and whether or not to normalise.